### PR TITLE
replace use of setuptools_scm

### DIFF
--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -111,6 +111,29 @@ def check_files(files, check):
     return result
 
 
+def apply_version():
+    print('Applying version string in setup.py')
+
+    p = subprocess.Popen(['git', 'describe', '--tags', '--match', 'v[0-9]*'], stdout=subprocess.PIPE)
+    out, err = p.communicate()
+    rc = p.wait()
+    if rc != 0:
+        raise RuntimeError("Cannot invoke git %s" % out)
+    tag = out.strip()
+
+    p = subprocess.Popen(['sed', '-i', "s/version=.*,/version='%s',/" % tag, 'setup.py'], stdout=subprocess.PIPE)
+    out, err = p.communicate()
+    rc = p.wait()
+    if rc != 0:
+        raise RuntimeError("Cannot invoke sed %s" % out)
+
+    p = subprocess.Popen(['git', 'add', 'setup.py'], stdout=subprocess.PIPE)
+    out, err = p.communicate()
+    rc = p.wait()
+    if rc != 0:
+        raise RuntimeError("Cannot invoke git %s" % out)
+
+
 def main(all_files, exclude=None):
     if not exclude:
         exclude = []
@@ -143,7 +166,10 @@ def main(all_files, exclude=None):
     for check in CHECKS:
         result = check_files(files, check) or result
 
-    sys.exit(result)
+    if files:
+        apply_version()
+
+    exit(result)
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ excludes = ["*tests*"]
 
 setup(
     name='iml-common',
-    use_scm_version=True,
-    setup_requires=['setuptools_scm'],
+    version='v1.0.3-6-gba6b698',
     license='MIT',
     packages=find_packages(exclude=excludes),
     include_package_data=True,


### PR DESCRIPTION
setuptools_scm is old and soon to be deprecated, its use in a python package's setup.py is causing problems with copr building straight from pypi. replace its usage

in order to commit with a valid package version, *scripts/pre-commit* file needs to be linked into the developers top-level *.git/hooks/* directory