### PR TITLE
Fix when to use threads by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: python
 python: '2.7'
-before_script:
-  - pip install codecov
-script:
-  - py.test --cov=iml_common
-after_success:
-  - codecov
+script: py.test --cov=./iml_common
+cache: false
+after_success: codecov
 deploy:
   provider: pypi
   skip_upload_docs: true

--- a/iml_common/lib/util.py
+++ b/iml_common/lib/util.py
@@ -11,22 +11,7 @@ import threading
 import platform
 from collections import namedtuple
 from collections import MutableSequence
-import sys
 import signal
-import traceback
-
-
-def running_isolated_tests():
-    """
-    Return true if the current application is running unit or module tests which require OS/platform mocking
-
-    A bit of a smorgasbord of tests to discover, but at least only one smorgasbord
-    """
-    return ('nosetests' in sys.argv[0]) or \
-           ('py.test' in sys.argv[0]) or \
-           ('pytest' in sys.argv[0]) or \
-           ('manage.py' in sys.argv[0] and 'test' in sys.argv[1]) or \
-           ('behave' in sys.argv[0])
 
 
 ExpiringValue = namedtuple('ExpiringValue', ['value', 'expiry'])
@@ -61,20 +46,15 @@ class ExpiringList(MutableSequence):
         self._container.insert(index, ExpiringValue(value, time.time() + self.grace_period))
 
 
-# When running unit tests every test is within a transaction and so if you kick of another thread you will not see
-# any of the database changes that have occurred. Threads will be enabled by default but manager unit tests must
-# explicitly set _use_threads_default to False to avoid database related failures. All other unit tests should
-# run threads because they don't use the manager db.
-# TODO: could the logic below be simplified to set _use_threads_default to False if string found in stack regardless
-stack = traceback.format_list(traceback.extract_stack())
-_use_threads_default = not (running_isolated_tests() and (any('manager/tests/unit' in line for line in stack) or
-                                                          ('behave' in sys.argv[0])))
-
-
 class ExceptionThrowingThread(threading.Thread):
     def __init__(self, *args, **kwargs):
-        # Sometimes not threading helps with debug.
-        self._use_threads = kwargs.pop('use_threads', _use_threads_default)
+        value = os.environ.get('IML_DISABLE_THREADS', '0')
+        # Sometimes not threading helps with debug, disabled by setting IML_DISABLE_THREADS=1
+        try:
+            self._use_threads = kwargs.pop('use_threads',
+                                           True if not value else not bool(int(value)))
+        except ValueError:
+            self._use_threads = True
 
         if self._use_threads:
             super(ExceptionThrowingThread, self).__init__(*args, **kwargs)
@@ -160,16 +140,7 @@ For a Mac it pretends to be Centos 7.2.
 
 :return: PlatformInfo named tuple
 """
-if running_isolated_tests():
-    # default platform_info attributes for agent unit tests (el6)
-    platform_info = PlatformInfo('Linux',
-                                 'CentOS',
-                                 '7.2',
-                                 '7.2.1551',
-                                 2.7,
-                                 7,
-                                 '3.10.0-327.36.3.el7.x86_64')
-elif platform.system() == 'Linux':
+if platform.system() == 'Linux':
     platform_info = PlatformInfo(platform.system(),
                                  platform.linux_distribution()[0],
                                  float('.'.join(platform.linux_distribution()[1].split('.')[:2])),

--- a/iml_common/lib/util.py
+++ b/iml_common/lib/util.py
@@ -140,7 +140,7 @@ For a Mac it pretends to be Centos 7.2.
 
 :return: PlatformInfo named tuple
 """
-if platform.system() == 'Linux':
+if platform.system() == 'Linux' and platform.linux_distribution()[0] == 'CentOS':
     platform_info = PlatformInfo(platform.system(),
                                  platform.linux_distribution()[0],
                                  float('.'.join(platform.linux_distribution()[1].split('.')[:2])),
@@ -149,7 +149,7 @@ if platform.system() == 'Linux':
                                                   platform.python_version_tuple()[1])),
                                  int(platform.python_version_tuple()[2]),
                                  platform.release())
-elif platform.system() == 'Darwin':
+elif platform.system() == 'Darwin' or platform.system() == 'Linux':
     platform_info = PlatformInfo('Linux',
                                  'CentOS',
                                  '7.2',

--- a/iml_common/test/iml_unit_testcase.py
+++ b/iml_common/test/iml_unit_testcase.py
@@ -6,17 +6,10 @@
 import mock
 
 from django.utils import unittest
-from iml_common.lib import util
 
 
 class ImlUnitTestCase(unittest.TestCase):
     def setUp(self):
-        mock.patch.object(util, 'platform_info', util.PlatformInfo('Linux',
-                                                                   'CentOS',
-                                                                   '7.2',
-                                                                   '7.2.1551',
-                                                                   2.7,
-                                                                   7,
-                                                                   '3.10.0-327.36.3.el7.x86_64')).start()
+        super(ImlUnitTestCase, self).setUp()
 
         self.addCleanup(mock.patch.stopall)

--- a/iml_common/test/iml_unit_testcase.py
+++ b/iml_common/test/iml_unit_testcase.py
@@ -6,8 +6,17 @@
 import mock
 
 from django.utils import unittest
+from iml_common.lib import util
 
 
 class ImlUnitTestCase(unittest.TestCase):
     def setUp(self):
+        mock.patch.object(util, 'platform_info', util.PlatformInfo('Linux',
+                                                                   'CentOS',
+                                                                   '7.2',
+                                                                   '7.2.1551',
+                                                                   2.7,
+                                                                   7,
+                                                                   '3.10.0-327.36.3.el7.x86_64')).start()
+
         self.addCleanup(mock.patch.stopall)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
-pytest
-pytest-cov
+codecov
+coverage==4.4.1
+pytest==3.1.2
+pytest-cov==2.5.1
 Django==1.4.5
 twine
 lockfile

--- a/tests/lib/test_service_control.py
+++ b/tests/lib/test_service_control.py
@@ -300,6 +300,14 @@ class TestServiceStateEL7(CommandCaptureTestCase):
     def setUp(self):
         super(TestServiceStateEL7, self).setUp()
 
+        mock.patch.object(util, 'platform_info', util.PlatformInfo('Linux',
+                                                                   'CentOS',
+                                                                   0.0,
+                                                                   '7.3',
+                                                                   0.0,
+                                                                   0,
+                                                                   '')).start()
+
         self.test = ServiceControl.create('test_service')
         self.assertEqual(type(self.test), ServiceControlEL7)
 

--- a/tests/lib/test_service_control.py
+++ b/tests/lib/test_service_control.py
@@ -300,14 +300,6 @@ class TestServiceStateEL7(CommandCaptureTestCase):
     def setUp(self):
         super(TestServiceStateEL7, self).setUp()
 
-        mock.patch.object(util, 'platform_info', util.PlatformInfo('Linux',
-                                                                   'CentOS',
-                                                                   0.0,
-                                                                   '7.2',
-                                                                   0.0,
-                                                                   0,
-                                                                   '')).start()
-
         self.test = ServiceControl.create('test_service')
         self.assertEqual(type(self.test), ServiceControlEL7)
 


### PR DESCRIPTION
*lib/util.py* defines _use_threads_default which dictates whether multiple threads are used in the running IML instance which has imported the iml_common module.

Multiple threads should by default be enabled and only disabled during manager unit tests (not really unit tests, but that's another story) which use the manager db during transactions. This is because the outcome of transactions cannot be correctly evaluated if multiple threads are accessing the same database during the tests.

The Logic for setting whether threads are enabled or not should be modified to evaluate whether the tests being run are manager unit tests. The reason this change is required is that we now have this logic outside of the chroma repo and the calling stack needs to be analysed.