### PR TITLE
Temporarily disable coverage in Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 python: '2.7'
-script: py.test --cov=./iml_common
-cache: false
-after_success: codecov
+script: py.test
 deploy:
   provider: pypi
   skip_upload_docs: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
-codecov
-coverage==4.4.1
-pytest==3.1.2
-pytest-cov==2.5.1
+pytest
 Django==1.4.5
 twine
 lockfile

--- a/tests/lib/test_util.py
+++ b/tests/lib/test_util.py
@@ -10,10 +10,6 @@ def target_func():
 
 class PreservePermissionTestCase(ImlUnitTestCase):
 
-    def setUp(self):
-        super(PreservePermissionTestCase, self).setUp()
-        environ.pop('IML_DISABLE_THREADS', None)
-
     def test_file(self):
         for filename, st_mode, st_uid, st_gid in [('sidney', 493, 2, 10),
                                                   ('denver', 362, 4, 7),
@@ -35,6 +31,17 @@ class PreservePermissionTestCase(ImlUnitTestCase):
             mock_os_chmod.assert_called_with(filename, magic_stat_mock.st_mode)
             self.assertEqual(mock_os_chown.call_count, 1)
             mock_os_chown.assert_called_with(filename, magic_stat_mock.st_uid, magic_stat_mock.st_gid)
+
+
+class DisableThreadsTestCase(ImlUnitTestCase):
+
+    def setUp(self):
+        super(DisableThreadsTestCase, self).setUp()
+        environ.pop('IML_DISABLE_THREADS', None)
+
+    def tearDown(self):
+        environ.pop('IML_DISABLE_THREADS', None)
+        super(DisableThreadsTestCase, self).tearDown()
 
     def test_threads_on(self):
         thread = util.ExceptionThrowingThread(target=target_func, args=())


### PR DESCRIPTION
Running coverage plug-in for pytest seems to be broken.

Temporarily remove running coverage to create the reports while we find a fix.

https://travis-ci.org/intel-hpdd/iml-common/builds/253755003
https://coverage.readthedocs.io/en/coverage-4.4.1/changes.html
https://bitbucket.org/ned/coveragepy/commits/74e2f7c366a2

