### PR TITLE
Directory for zfs filelocks not getting created as parent directory doesn't exist

### DIFF
--- a/iml_common/blockdevices/blockdevice_zfs.py
+++ b/iml_common/blockdevices/blockdevice_zfs.py
@@ -50,7 +50,7 @@ class ZfsDevice(object):
     operate on the device as if it was locally active.
     """
 
-    ZPOOL_LOCK_DIR = '/var/lib/iml-common/zfs_locks'
+    ZPOOL_LOCK_DIR = '/var/lib/iml/zfs_locks'
     LOCK_ACQUIRE_TIMEOUT = 10
 
     lock_refcount = defaultdict(int)
@@ -121,7 +121,7 @@ class ZfsDevice(object):
         if ZfsDevice.locks_dir_initialized is False:
             # ensure lock directory exists
             try:
-                os.mkdir(self.ZPOOL_LOCK_DIR)
+                os.makedirs(self.ZPOOL_LOCK_DIR)
             except OSError:
                 pass
 
@@ -503,6 +503,12 @@ class BlockDeviceZfs(BlockDevice):
         :return: None on success, error message on failure
         """
         error = None
+
+        # ensure lock directory exists
+        try:
+            os.makedirs(ZfsDevice.ZPOOL_LOCK_DIR)
+        except OSError:
+            pass
 
         if managed_mode is False:
             return error

--- a/tests/blockdevices/test_zfs_device.py
+++ b/tests/blockdevices/test_zfs_device.py
@@ -264,7 +264,7 @@ class TestZfsDeviceLockFile(TestZfsDevice):
         self.thread_running = False
 
         shutil.rmtree(ZfsDevice.ZPOOL_LOCK_DIR, ignore_errors=True)
-        os.mkdir(ZfsDevice.ZPOOL_LOCK_DIR)
+        os.makedirs(ZfsDevice.ZPOOL_LOCK_DIR)
 
     def tearDown(self):
         shutil.rmtree(ZfsDevice.ZPOOL_LOCK_DIR, ignore_errors=True)
@@ -415,15 +415,15 @@ class TestZfsDeviceLockFile(TestZfsDevice):
         ZfsDevice.locks_dir_initialized = False
         zfs_device = ZfsDevice(self.zpool_name, False)
 
-        mock_mkdir = mock.Mock()
-        with mock.patch('os.mkdir', mock_mkdir):
+        mock_makedirs = mock.Mock()
+        with mock.patch('os.makedirs', mock_makedirs):
             zfs_device.lock_pool()
 
-            mock_mkdir.assert_called_once_with(ZfsDevice.ZPOOL_LOCK_DIR)
-            mock_mkdir.reset_mock()
+            mock_makedirs.assert_called_once_with(ZfsDevice.ZPOOL_LOCK_DIR)
+            mock_makedirs.reset_mock()
 
             zfs_device.lock_pool()
 
-            mock_mkdir.assert_not_called()
+            mock_makedirs.assert_not_called()
 
         ZfsDevice.locks_dir_initialized = False


### PR DESCRIPTION
path of target  directory includes parent directory that doesn't exist