### PR TITLE
Remove 'force' flags from import methods

### DIFF
--- a/iml_common/blockdevices/blockdevice_zfs.py
+++ b/iml_common/blockdevices/blockdevice_zfs.py
@@ -87,7 +87,7 @@ class ZfsDevice(object):
 
             if self.pool_path not in imported_pools:
                 try:
-                    result = self.import_(True, True)
+                    result = self.import_(True)
                     self.pool_imported = (result is None)
                 except:
                     self.unlock_pool()
@@ -155,7 +155,7 @@ class ZfsDevice(object):
         if self.lock_refcount[self.lock_unique_id] == 0:
             self.lock.release()
 
-    def import_(self, force, readonly):
+    def import_(self, readonly):
         """
         This must be called when doing an import as it will lock the device before doing imports and ensure there is
         no confusion about whether a device is import or not.
@@ -166,7 +166,6 @@ class ZfsDevice(object):
 
         try:
             return shell.Shell.run_canned_error_message(['zpool', 'import'] +
-                                                        (['-f'] if force else []) +
                                                         (['-N', '-o', 'readonly=on', '-o', 'cachefile=none'] if readonly else []) +
                                                         [self.pool_path])
         finally:
@@ -342,7 +341,7 @@ class BlockDeviceZfs(BlockDevice):
 
                 for line in ls.split("\n"):
                     try:
-                        key, value = line.split('\t')
+                        key, value = line.split()
                         self._zfs_properties[key] = value
                     except ValueError:                              # Be resilient to things we don't understand.
                         if log:
@@ -372,7 +371,7 @@ class BlockDeviceZfs(BlockDevice):
 
                 for line in ls.strip().split("\n"):
                     try:
-                        _, key, value, _ = line.split('\t')
+                        _, key, value, _ = line.split()
                         self._zpool_properties[key] = value
                     except ValueError:                              # Be resilient to things we don't understand.
                         if log:
@@ -446,7 +445,7 @@ class BlockDeviceZfs(BlockDevice):
             return blockdevice.import_(pacemaker_ha_operation)
 
         with ZfsDevice(self._device_path, False) as zfs_device:
-            result = zfs_device.import_(pacemaker_ha_operation, False)
+            result = zfs_device.import_(False)
 
             if result is not None and 'a pool with that name already exists' in result:
 

--- a/tests/blockdevices/blockdevice_base_tests.py
+++ b/tests/blockdevices/blockdevice_base_tests.py
@@ -65,17 +65,8 @@ class BaseTestBD(object):
         def test_property_values(self):
             pass
 
-        def test_import_success_non_pacemaker(self):
+        def test_import_success(self):
             self.assertIsNone(self.blockdevice.import_(False))
-
-        def test_import_success_with_pacemaker(self):
-            self.assertIsNone(self.blockdevice.import_(True))
-
-        def test_import_existing_non_pacemaker(self):
-            self.assertIsNone(self.blockdevice.import_(False))
-
-        def test_import_existing_with_pacemaker(self):
-            self.assertIsNone(self.blockdevice.import_(True))
 
         def test_export_success(self):
             self.assertIsNone(self.blockdevice.export())

--- a/tests/blockdevices/test_zfs_device.py
+++ b/tests/blockdevices/test_zfs_device.py
@@ -30,7 +30,7 @@ class TestZfsDevice(CommandCaptureTestCase):
         self.add_commands(CommandCaptureCommand(('zpool', 'list', '-H', '-o', 'name'), stdout=name))
 
         if name != self.zpool_name:
-            self.add_commands(CommandCaptureCommand(('zpool', 'import', '-f', '-N', '-o', 'readonly=on', '-o', 'cachefile=none', self.zpool_name)))
+            self.add_commands(CommandCaptureCommand(('zpool', 'import', '-N', '-o', 'readonly=on', '-o', 'cachefile=none', self.zpool_name)))
 
     def _add_export_commands(self):
         self.add_commands(CommandCaptureCommand(('zpool', 'export', self.zpool_name)))
@@ -73,23 +73,21 @@ class TestZfsDeviceImportExport(TestZfsDevice):
         self.zfs_device.lock.is_locked.return_value ^= True
 
     def test_import(self):
-        for force in [True, False]:
-            for readonly in [True, False]:
-                self.reset_command_capture()
+        for readonly in [True, False]:
+            self.reset_command_capture()
 
-                self.add_commands(CommandCaptureCommand(('zpool', 'import') +
-                                                        (('-f',) if force else ()) +
-                                                        (('-N', '-o', 'readonly=on', '-o', 'cachefile=none') if readonly else ()) +
-                                                        (self.zpool_name,)))
+            self.add_commands(CommandCaptureCommand(('zpool', 'import') +
+                                                    (('-N', '-o', 'readonly=on', '-o', 'cachefile=none') if readonly else ()) +
+                                                    (self.zpool_name,)))
 
-                self.zfs_device.import_(force, readonly)
+            self.zfs_device.import_(readonly)
 
-                self.zfs_device.lock.acquire.assert_called_once_with(ZfsDevice.LOCK_ACQUIRE_TIMEOUT)
-                self.zfs_device.lock.release.assert_called_once_with()
-                self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), 0)
+            self.zfs_device.lock.acquire.assert_called_once_with(ZfsDevice.LOCK_ACQUIRE_TIMEOUT)
+            self.zfs_device.lock.release.assert_called_once_with()
+            self.assertEqual(ZfsDevice.lock_refcount.get(self.zfs_device.lock_unique_id), 0)
 
-                self.assertRanAllCommandsInOrder()
-                self.zfs_device.lock.reset_mock()
+            self.assertRanAllCommandsInOrder()
+            self.zfs_device.lock.reset_mock()
 
     def test_import_writable(self):
         self._add_import_commands()
@@ -173,7 +171,7 @@ class TestZfsDeviceImportExport(TestZfsDevice):
 
     def test_error_in_import(self):
         self.add_commands(CommandCaptureCommand(('zpool', 'list', '-H', '-o', 'name'), stdout='Boris'),
-                          CommandCaptureCommand(('zpool', 'import', '-f', '-N', '-o', 'readonly=on', '-o', 'cachefile=none',
+                          CommandCaptureCommand(('zpool', 'import', '-N', '-o', 'readonly=on', '-o', 'cachefile=none',
                                                  self.zpool_name), rc=1))
 
         exported_zfs_device = self._get_zfs_device(self.zpool_name, True)
@@ -273,7 +271,7 @@ class TestZfsDeviceLockFile(TestZfsDevice):
         self.add_command(('zpool', 'import', self.zpool_name))
         self.thread_running = True
         zfs_device = ZfsDevice(self.zpool_name, False)
-        zfs_device.import_(False, False)
+        zfs_device.import_(False)
         self.assertFalse(zfs_device.lock.i_am_locking())
         self.thread_running = False
 

--- a/tests/data/example_data.py
+++ b/tests/data/example_data.py
@@ -112,6 +112,49 @@ Journal features:         journal_incompat_revoke
 Journal size:             8M
 Journal length:           8192
 Journal sequence:         0x00000365
-Journal start:            1
+Journal start:            1"""
 
-"""
+# example commandline stdout from command of the format:
+# >> zpool get -Hp all <zpool name>
+zpool_example_properties = """bob     size    10670309376     -
+bob     capacity        0       -
+bob     altroot -       default
+bob     health  ONLINE  -
+bob     guid    14447627934634597108    -
+bob     version -       default
+bob     bootfs  -       default
+bob     delegation      on      default
+bob     autoreplace     off     default
+bob     cachefile       -       default
+bob     failmode        panic   local
+bob     listsnapshots   off     default
+bob     autoexpand      off     default
+bob     dedupditto      0       default
+bob     dedupratio      1.00    -
+bob     free    10670149632     -
+bob     allocated       159744  -
+bob     readonly        off     -
+bob     ashift  0       default
+bob     comment -       default
+bob     expandsize      -       -
+bob     freeing 0       -
+bob     fragmentation   0       -
+bob     leaked  0       -
+bob     multihost       on      local
+bob     feature@async_destroy   enabled local
+bob     feature@empty_bpobj     active  local
+bob     feature@lz4_compress    active  local
+bob     feature@multi_vdev_crash_dump   enabled local
+bob     feature@spacemap_histogram      active  local
+bob     feature@enabled_txg     active  local
+bob     feature@hole_birth      active  local
+bob     feature@extensible_dataset      active  local
+bob     feature@embedded_data   active  local
+bob     feature@bookmarks       enabled local
+bob     feature@filesystem_limits       enabled local
+bob     feature@large_blocks    enabled local
+bob     feature@large_dnode     enabled local
+bob     feature@sha512  enabled local
+bob     feature@skein   enabled local
+bob     feature@edonr   enabled local
+bob     feature@userobj_accounting      active  local"""


### PR DESCRIPTION
This patch will not require any change in any code that uses agent import calls (no iml-common API changes). The use of 'force' zpool imports inside this module is removed with this patch.

The enforcement of zfs MMP in Lustre means that force zpool imports are no longer feasible when a pool is imported elsewhere. As force imports no longer enable us to 'peek' the state of zpools during device scans and double imports are inherently risky, the use of the force flag should be removed.

https://github.com/intel-hpdd/intel-manager-for-lustre/pull/244 implements changes to avoid the need for double imports during zfs device scanning.