### PR TITLE
Remove 'pacemaker_ha_operation' parameter from BlockDevice.import_ method

### DIFF
--- a/iml_common/blockdevices/blockdevice.py
+++ b/iml_common/blockdevices/blockdevice.py
@@ -119,13 +119,11 @@ class BlockDevice(object):
     def targets(self, uuid_name_to_target, device, log):
         pass
 
-    def import_(self, pacemaker_ha_operation):
+    def import_(self):
         """
         If appropriate import the blockdevice, this is required for many devices where only 1 node may have the device
         imported at a time. zpools for example.
 
-        :param pacemaker_ha_operation: This import is at the request of pacemaker. In HA operations the device may
-               often have not have been cleanly exported because the previous mounted node failed in operation.
         :return: None on success or error message on failure
         """
         return None

--- a/iml_common/blockdevices/blockdevice_zfs.py
+++ b/iml_common/blockdevices/blockdevice_zfs.py
@@ -424,15 +424,13 @@ class BlockDeviceZfs(BlockDevice):
 
         return self.TargetsInfo(names, params)
 
-    def import_(self, pacemaker_ha_operation):
+    def import_(self):
         """
         Before importing check the device_path does not reference a dataset, if it does then retry on parent zpool
         block device.
 
         We can only import the zpool if it's not already imported so check before importing.
 
-        :param pacemaker_ha_operation: This import is at the request of pacemaker. In HA operations the device may
-               often have not have been cleanly exported because the previous mounted node failed in operation.
         :return: None for success meaning the zpool is imported
         """
         self._initialize_modules()
@@ -442,7 +440,7 @@ class BlockDeviceZfs(BlockDevice):
         except NotZpoolException:
             blockdevice = BlockDevice(self._supported_device_types[0], self._device_path.split('/')[0])
 
-            return blockdevice.import_(pacemaker_ha_operation)
+            return blockdevice.import_()
 
         with ZfsDevice(self._device_path, False) as zfs_device:
             result = zfs_device.import_(False)
@@ -456,7 +454,7 @@ class BlockDeviceZfs(BlockDevice):
                     if result is not None:
                         return "zpool was imported readonly, and failed to export: '%s'" % result
 
-                    result = self.import_(pacemaker_ha_operation)
+                    result = self.import_()
 
                     if (result is None) and (self.zpool_properties(True).get('readonly') == 'on'):
                         return 'zfs pool %s can only be imported readonly, is it in use?' % self._device_path

--- a/tests/blockdevices/blockdevice_base_tests.py
+++ b/tests/blockdevices/blockdevice_base_tests.py
@@ -66,7 +66,7 @@ class BaseTestBD(object):
             pass
 
         def test_import_success(self):
-            self.assertIsNone(self.blockdevice.import_(False))
+            self.assertIsNone(self.blockdevice.import_())
 
         def test_export_success(self):
             self.assertIsNone(self.blockdevice.export())

--- a/tests/blockdevices/test_blockdevice_zfs.py
+++ b/tests/blockdevices/test_blockdevice_zfs.py
@@ -156,7 +156,7 @@ kernel modules are functioning properly.
         self.blockdevice = BlockDeviceZfs('zfs', self.dataset_path)
         self.add_commands(CommandCaptureCommand(('zpool', 'import', self.pool_name)))
 
-        self.assertIsNone(self.blockdevice.import_(False))
+        self.assertIsNone(self.blockdevice.import_())
         self.assertRanAllCommandsInOrder()
 
     def test_import_existing_readonly(self):
@@ -183,7 +183,7 @@ kernel modules are functioning properly.
                           CommandCaptureCommand(('zpool', 'get', '-Hp', 'all', self.pool_name),
                                                 stdout=example_data.zpool_example_properties))
 
-        self.assertIsNone(self.blockdevice.import_(False))
+        self.assertIsNone(self.blockdevice.import_())
         self.assertRanAllCommandsInOrder()
 
     def test_export_success(self):


### PR DESCRIPTION
This patch will require a change in any code that uses agent import calls, complementary IML patch is https://github.com/intel-hpdd/intel-manager-for-lustre/pull/262 .