### PR TITLE
Remove store.json when initialising and terminating blockdevice driver

### DIFF
--- a/iml_common/blockdevices/blockdevice_zfs.py
+++ b/iml_common/blockdevices/blockdevice_zfs.py
@@ -510,6 +510,12 @@ class BlockDeviceZfs(BlockDevice):
         except OSError:
             pass
 
+        # remove json store for zfs objects
+        try:
+            os.remove('/tmp/store.json')
+        except OSError:
+            pass
+
         if managed_mode is False:
             return error
 
@@ -575,6 +581,12 @@ class BlockDeviceZfs(BlockDevice):
         Iterate through existing lockfiles and for each check if pid written into lock is THIS process' pid and
         if so, remove lockfile. If no pid written into lockfile, ignore (linklockfiles).
         """
+        # remove json store for zfs objects
+        try:
+            os.remove('/tmp/store.json')
+        except OSError:
+            pass
+
         lockfile_paths = [os.path.join(ZfsDevice.ZPOOL_LOCK_DIR, name) for name in os.listdir(ZfsDevice.ZPOOL_LOCK_DIR)]
 
         def validate_or_remove(path):

--- a/tests/blockdevices/test_blockdevice_zfs.py
+++ b/tests/blockdevices/test_blockdevice_zfs.py
@@ -386,8 +386,6 @@ kernel modules are functioning properly.
         self.assertRanAllCommandsInOrder()
 
     def _base_terminate_driver_test(self, getpid_retval, listdir_retval, lockfilepid_retval):
-        # mock_remove = mock.Mock()
-        # mock.patch('os.remove', mock_remove).start()
         mock_getpid = mock.Mock(return_value=getpid_retval)
         mock.patch('os.getpid', mock_getpid).start()
         mock_listdir = mock.Mock(return_value=listdir_retval)


### PR DESCRIPTION
clear up store json file during initialisation and termination