### PR TITLE
Add ENOENT to the list of retryable mount failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,21 @@
 include Makefile.local
 
-VERSION       := $(shell git describe --tags | sed -e 's/^v//' -e 's/RC[0-9]*//')
-RPM_TOPDIR    := $(shell rpm --eval %_topdir)
-RPM_SOURCEDIR := $(shell rpm --eval %_sourcedir)
-RPM_RPMSDIR   := $(shell rpm --eval %_rpmdir)
+VERSION        := $(shell git describe --tags | sed -e 's/^v//' -e 's/RC[0-9]*//' -e 's/-g.*//')
+VERSION_PARTS  := $(subst ., ,$(VERSION))
+VERSION_MAJOR  := $(word 1, $(VERSION_PARTS))
+VERSION_MINOR  := $(word 2, $(VERSION_PARTS))
+VERSION_BUGFIX := $(word 3, $(VERSION_PARTS))
+VERSION_LOCAL1 := $(word 4, $(VERSION_PARTS))
+VERSION_LOCAL2 := $(word 5, $(VERSION_PARTS))
+RPM_TOPDIR     := $(shell rpm --eval %_topdir)
+RPM_SOURCEDIR  := $(shell rpm --eval %_sourcedir)
+RPM_RPMSDIR    := $(shell rpm --eval %_rpmdir)
 
 rpm: $(RPM_RPMSDIR)/noarch/python2-iml-common-$(VERSION)-1.el7.centos.noarch.rpm
 
-srpm: python-iml-common-$(VERSION)-1.el7.centos.src.rpm
+srpm: python-iml-common$(VERSION_MAJOR).$(VERSION_MINOR)-$(VERSION)-1.el7.centos.src.rpm
 
-python-iml-common-$(VERSION)-1.el7.centos.src.rpm: iml-common-$(VERSION).spec
+python-iml-common$(VERSION_MAJOR).$(VERSION_MINOR)-$(VERSION)-1.el7.centos.src.rpm: iml-common-$(VERSION).spec
 	rpmbuild -bs --define %_srcrpmdir\ $$PWD --define %_sourcedir\ dist $<
 
 spec: iml-common-$(VERSION).spec
@@ -19,7 +25,7 @@ dist: dist/iml-common-$(VERSION).tar.gz
 version:
 	@echo $(VERSION)
 
-copr_rpm: python-iml-common-$(VERSION)-1.el7.centos.src.rpm
+copr_rpm: python-iml-common$(VERSION_MAJOR).$(VERSION_MINOR)-$(VERSION)-1.el7.centos.src.rpm
 	set -e;                                                    \
 	if [ -z "$(COPR_OWNER)" -o                                 \
 	     -z "$(COPR_PROJECT)" ]; then                          \
@@ -30,11 +36,11 @@ copr_rpm: python-iml-common-$(VERSION)-1.el7.centos.src.rpm
 	fi
 	copr-cli build $(COPR_OWNER)/$(COPR_PROJECT) $<
 
-$(RPM_RPMSDIR)/noarch/python2-iml-common-$(VERSION)-1.el7.centos.noarch.rpm: iml-common-$(VERSION).spec
-	rpmbuild -bb $<
+$(RPM_RPMSDIR)/noarch/python2-iml-common-$(VERSION)-1.el7.centos.noarch.rpm: iml-common-$(VERSION).spec dist/iml-common-$(VERSION).tar.gz
+	rpmbuild -bb --define %_sourcedir\ $$PWD/dist $<
 
-iml-common-$(VERSION).spec: dist/iml-common-$(VERSION).tar.gz Makefile
-	pyp2rpm -p 2 -d $(RPM_TOPDIR) $< | sed -e "s/^Source0:.*/Source0:        iml-common-$(VERSION).tar.gz/" -e 's/python-setuptools-scm/python2-setuptools_scm/g' > $@
+iml-common-$(VERSION).spec: Makefile
+	curl 'https://raw.githubusercontent.com/intel-hpdd/manager-for-lustre-dependencies/python-iml-common$(VERSION_MAJOR).$(VERSION_MINOR)-$(VERSION_MAJOR).$(VERSION_MINOR).$(VERSION_BUGFIX)-1/python-iml-common/python-iml-common.spec' | sed -e '/^%global patch/s/$$/.$(VERSION_LOCAL1).$(VERSION_LOCAL2)/' -e '/Source0:/s/^\(.*  *\).*/\1iml-common-%{version}.tar.gz/' > $@
 
 dist/iml-common-$(VERSION).tar.gz:
 	python setup.py sdist

--- a/iml_common/filesystems/filesystem.py
+++ b/iml_common/filesystems/filesystem.py
@@ -20,6 +20,7 @@ class FileSystem(object):
 
     RC_MOUNT_SUCCESS = 0
     RC_MOUNT_INPUT_OUTPUT_ERROR = 5
+    RC_MOUNT_ENOENT_ERROR = 2
     RC_MOUNT_ESHUTDOWN_ERROR = 108
 
     class_override = None
@@ -80,9 +81,10 @@ class FileSystem(object):
 
         result = shell.Shell.run(['mount', '-t', 'lustre', self._device_path, mount_point])
 
-        if result.rc == self.RC_MOUNT_INPUT_OUTPUT_ERROR or \
-           result.rc == self.RC_MOUNT_ESHUTDOWN_ERROR:
-            # HYD-1040, LU-9838: Sometimes we should retry on a failed registration
+        if result.rc in [self.RC_MOUNT_INPUT_OUTPUT_ERROR,
+                         self.RC_MOUNT_ENOENT_ERROR,
+                         self.RC_MOUNT_ESHUTDOWN_ERROR]:
+            # HYD-1040, LU-9838, LU-9976: Sometimes we should retry on a failed registration
             result = shell.Shell.run(['mount', '-t', 'lustre', self._device_path, mount_point])
 
         if result.rc != self.RC_MOUNT_SUCCESS:

--- a/tests/filesystems/test_filesystem_ldiskfs.py
+++ b/tests/filesystems/test_filesystem_ldiskfs.py
@@ -51,6 +51,9 @@ class TestFileSystemLdiskfs(CommandCaptureTestCase):
     def test_mount_fail_initial_108(self):
         self._mount_fail_initial(108)
 
+    def test_mount_fail_initial_2(self):
+        self._mount_fail_initial(2)
+
     def test_mount_different_rc_fail_initial(self):
         """ Test when initial mount fails and the rc doesn't cause a retry, exception is raised """
         self.add_commands(CommandCaptureCommand(('mount', '-t', 'lustre', '/dev/sda1', '/mnt/OST0000'), rc=1,


### PR DESCRIPTION
Fixes intel-hpdd/intel-manager-for-lustre#272

Per HYD-9976, ENOENT (-2) is an error we should be able to safely
retry the mount upon hitting.