### PR TITLE
Re enable pacemaker force import

### DIFF
--- a/iml_common/blockdevices/blockdevice.py
+++ b/iml_common/blockdevices/blockdevice.py
@@ -119,11 +119,13 @@ class BlockDevice(object):
     def targets(self, uuid_name_to_target, device, log):
         pass
 
-    def import_(self):
+    def import_(self, pacemaker_ha_operation):
         """
         If appropriate import the blockdevice, this is required for many devices where only 1 node may have the device
         imported at a time. zpools for example.
 
+        :param pacemaker_ha_operation: This import is at the request of pacemaker. In HA operations the device may
+               often have not have been cleanly exported because the previous mounted node failed in operation.
         :return: None on success or error message on failure
         """
         return None

--- a/iml_common/blockdevices/blockdevice_zfs.py
+++ b/iml_common/blockdevices/blockdevice_zfs.py
@@ -170,6 +170,7 @@ class ZfsDevice(object):
 
         try:
             return Shell.run_canned_error_message(['zpool', 'import'] +
+                                                  (['-f'] if force else []) +
                                                   (['-N', '-o', 'readonly=on', '-o', 'cachefile=none'] if readonly else []) +
                                                   [self.pool_path])
         finally:

--- a/iml_common/blockdevices/blockdevice_zfs.py
+++ b/iml_common/blockdevices/blockdevice_zfs.py
@@ -424,13 +424,15 @@ class BlockDeviceZfs(BlockDevice):
 
         return self.TargetsInfo(names, params)
 
-    def import_(self):
+    def import_(self, pacemaker_ha_operation):
         """
         Before importing check the device_path does not reference a dataset, if it does then retry on parent zpool
         block device.
 
         We can only import the zpool if it's not already imported so check before importing.
 
+        :param pacemaker_ha_operation: This import is at the request of pacemaker. In HA operations the device may
+               often have not have been cleanly exported because the previous mounted node failed in operation.
         :return: None for success meaning the zpool is imported
         """
         self._initialize_modules()
@@ -440,7 +442,7 @@ class BlockDeviceZfs(BlockDevice):
         except NotZpoolException:
             blockdevice = BlockDevice(self._supported_device_types[0], self._device_path.split('/')[0])
 
-            return blockdevice.import_()
+            return blockdevice.import_(pacemaker_ha_operation)
 
         with ZfsDevice(self._device_path, False) as zfs_device:
             result = zfs_device.import_(False)
@@ -454,7 +456,7 @@ class BlockDeviceZfs(BlockDevice):
                     if result is not None:
                         return "zpool was imported readonly, and failed to export: '%s'" % result
 
-                    result = self.import_()
+                    result = self.import_(pacemaker_ha_operation)
 
                     if (result is None) and (self.zpool_properties(True).get('readonly') == 'on'):
                         return 'zfs pool %s can only be imported readonly, is it in use?' % self._device_path

--- a/iml_common/blockdevices/blockdevice_zfs.py
+++ b/iml_common/blockdevices/blockdevice_zfs.py
@@ -91,7 +91,7 @@ class ZfsDevice(object):
 
             if self.pool_path not in imported_pools:
                 try:
-                    result = self.import_(True, True)
+                    result = self.import_(False, True)
                     self.pool_imported = (result is None)
                 except:
                     self.unlock_pool()

--- a/tests/blockdevices/blockdevice_base_tests.py
+++ b/tests/blockdevices/blockdevice_base_tests.py
@@ -65,8 +65,17 @@ class BaseTestBD(object):
         def test_property_values(self):
             pass
 
-        def test_import_success(self):
+        def test_import_success_non_pacemaker(self):
             self.assertIsNone(self.blockdevice.import_(False))
+
+        def test_import_success_with_pacemaker(self):
+            self.assertIsNone(self.blockdevice.import_(True))
+
+        def test_import_existing_non_pacemaker(self):
+            self.assertIsNone(self.blockdevice.import_(False))
+
+        def test_import_existing_with_pacemaker(self):
+            self.assertIsNone(self.blockdevice.import_(True))
 
         def test_export_success(self):
             self.assertIsNone(self.blockdevice.export())

--- a/tests/blockdevices/blockdevice_base_tests.py
+++ b/tests/blockdevices/blockdevice_base_tests.py
@@ -66,7 +66,7 @@ class BaseTestBD(object):
             pass
 
         def test_import_success(self):
-            self.assertIsNone(self.blockdevice.import_())
+            self.assertIsNone(self.blockdevice.import_(False))
 
         def test_export_success(self):
             self.assertIsNone(self.blockdevice.export())

--- a/tests/blockdevices/test_blockdevice_zfs.py
+++ b/tests/blockdevices/test_blockdevice_zfs.py
@@ -159,7 +159,7 @@ kernel modules are functioning properly.
         self.blockdevice = BlockDeviceZfs('zfs', self.dataset_path)
         self.add_commands(CommandCaptureCommand(('zpool', 'import', self.pool_name)))
 
-        self.assertIsNone(self.blockdevice.import_())
+        self.assertIsNone(self.blockdevice.import_(False))
         self.assertRanAllCommandsInOrder()
 
     def test_import_existing_readonly(self):
@@ -186,7 +186,7 @@ kernel modules are functioning properly.
                           CommandCaptureCommand(('zpool', 'get', '-Hp', 'all', self.pool_name),
                                                 stdout=example_data.zpool_example_properties))
 
-        self.assertIsNone(self.blockdevice.import_())
+        self.assertIsNone(self.blockdevice.import_(False))
         self.assertRanAllCommandsInOrder()
 
     def test_export_success(self):

--- a/tests/blockdevices/test_zfs_device.py
+++ b/tests/blockdevices/test_zfs_device.py
@@ -30,7 +30,7 @@ class TestZfsDevice(CommandCaptureTestCase):
         self.add_commands(CommandCaptureCommand(('zpool', 'list', '-H', '-o', 'name'), stdout=name))
 
         if name != self.zpool_name:
-            self.add_commands(CommandCaptureCommand(('zpool', 'import', '-f', '-N', '-o', 'readonly=on', '-o', 'cachefile=none', self.zpool_name)))
+            self.add_commands(CommandCaptureCommand(('zpool', 'import', '-N', '-o', 'readonly=on', '-o', 'cachefile=none', self.zpool_name)))
 
     def _add_export_commands(self):
         self.add_commands(CommandCaptureCommand(('zpool', 'export', self.zpool_name)))
@@ -173,7 +173,7 @@ class TestZfsDeviceImportExport(TestZfsDevice):
 
     def test_error_in_import(self):
         self.add_commands(CommandCaptureCommand(('zpool', 'list', '-H', '-o', 'name'), stdout='Boris'),
-                          CommandCaptureCommand(('zpool', 'import', '-f', '-N', '-o', 'readonly=on', '-o', 'cachefile=none',
+                          CommandCaptureCommand(('zpool', 'import', '-N', '-o', 'readonly=on', '-o', 'cachefile=none',
                                                  self.zpool_name), rc=1))
 
         exported_zfs_device = self._get_zfs_device(self.zpool_name, True)


### PR DESCRIPTION
counterpart patch for https://github.com/intel-hpdd/intel-manager-for-lustre/pull/317

reverts the commits necessary to re-enable the use of force import when  pacemaker issues import