### PR TITLE
Clean up duplication of filelock directory creation

### DIFF
--- a/iml_common/blockdevices/blockdevice_zfs.py
+++ b/iml_common/blockdevices/blockdevice_zfs.py
@@ -58,7 +58,6 @@ class ZfsDevice(object):
     LOCK_ACQUIRE_TIMEOUT = 10
 
     lock_refcount = defaultdict(int)
-    locks_dir_initialized = False
 
     def __init__(self, device_path, try_import):
         """
@@ -122,15 +121,6 @@ class ZfsDevice(object):
 
         Lock acquire polls the timeout at intervals of LOCK_ACQUIRE_TIMEOUT.
         """
-        if ZfsDevice.locks_dir_initialized is False:
-            # ensure lock directory exists
-            try:
-                os.makedirs(self.ZPOOL_LOCK_DIR)
-            except OSError:
-                pass
-
-            ZfsDevice.locks_dir_initialized = True
-
         while not self.lock.i_am_locking():
             try:
                 self.lock.acquire(self.LOCK_ACQUIRE_TIMEOUT)

--- a/tests/blockdevices/test_zfs_device.py
+++ b/tests/blockdevices/test_zfs_device.py
@@ -409,21 +409,3 @@ class TestZfsDeviceLockFile(TestZfsDevice):
         self.assertEqual(mock_kill.call_count, 1)
         self.assertEqual(contents, [str(zfs_device.lock.pid)])
         self.assertEqual(ZfsDevice.lock_refcount.get(zfs_device.lock_unique_id), 1)
-
-    def test_not_initialised(self):
-        """ check lock directory is initialised """
-        ZfsDevice.locks_dir_initialized = False
-        zfs_device = ZfsDevice(self.zpool_name, False)
-
-        mock_makedirs = mock.Mock()
-        with mock.patch('os.makedirs', mock_makedirs):
-            zfs_device.lock_pool()
-
-            mock_makedirs.assert_called_once_with(ZfsDevice.ZPOOL_LOCK_DIR)
-            mock_makedirs.reset_mock()
-
-            zfs_device.lock_pool()
-
-            mock_makedirs.assert_not_called()
-
-        ZfsDevice.locks_dir_initialized = False


### PR DESCRIPTION
Directory is initialised in multiple places, avoid initialising twice