### PR TITLE
Remove disable of ZFS services

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.swo
 *.log
 .DS_Store
+.pytest_cache

--- a/iml_common/blockdevices/blockdevice_zfs.py
+++ b/iml_common/blockdevices/blockdevice_zfs.py
@@ -535,26 +535,6 @@ class BlockDeviceZfs(BlockDevice):
                 error = 'Error preparing nodes for ZFS multimount protection. gethostid failed with %s' \
                         % result.stderr
 
-        def disable_if_exists(name):
-            status = Shell.run(['systemctl', 'status', name])
-
-            if status.rc != 4:
-                return Shell.run_canned_error_message([
-                    'systemctl',
-                    'disable',
-                    name
-                ])
-
-        if error is None:
-            error = reduce(
-                lambda x, y: x if x is not None else disable_if_exists(y),
-                ['zfs.target',
-                 'zfs-import-scan',
-                 'zfs-import-cache',
-                 'zfs-mount'],
-                None
-            )
-
         # https://github.com/zfsonlinux/zfs/issues/3801 describes a case where dkms will not rebuild zfs/spl in the
         # case of an upgrade. The command below ensures that dkms updates zfs/spl after our install which may have lead
         # to a kernel update.

--- a/tests/blockdevices/test_blockdevice_zfs.py
+++ b/tests/blockdevices/test_blockdevice_zfs.py
@@ -271,14 +271,6 @@ kernel modules are functioning properly.
 
     def test_initialise_driver(self):
         self.add_commands(CommandCaptureCommand(('genhostid',)),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs.target')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs.target')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-import-scan')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-import-scan')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-import-cache')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-import-cache')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-mount')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-mount')),
                           CommandCaptureCommand(('rpm', '-qi', 'spl'), stdout=self.rpm_qi_spl_stdout),
                           CommandCaptureCommand(('dkms', 'install', 'spl/1.2.3.4')),
                           CommandCaptureCommand(('modprobe', 'spl')),
@@ -295,15 +287,7 @@ kernel modules are functioning properly.
         self.assertRanAllCommandsInOrder()
 
     def test_initialise_driver_file_exists(self):
-        self.add_commands(CommandCaptureCommand(('systemctl', 'status', 'zfs.target')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs.target')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-import-scan')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-import-scan')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-import-cache')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-import-cache')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-mount')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-mount')),
-                          CommandCaptureCommand(('rpm', '-qi', 'spl'), stdout=self.rpm_qi_spl_stdout),
+        self.add_commands(CommandCaptureCommand(('rpm', '-qi', 'spl'), stdout=self.rpm_qi_spl_stdout),
                           CommandCaptureCommand(('dkms', 'install', 'spl/1.2.3.4')),
                           CommandCaptureCommand(('modprobe', 'spl')),
                           CommandCaptureCommand(('rpm', '-qi', 'zfs'), stdout=self.rpm_qi_zfs_stdout),
@@ -331,14 +315,6 @@ kernel modules are functioning properly.
 
     def test_initialise_driver_fail_dkms_spl(self):
         self.add_commands(CommandCaptureCommand(('genhostid',)),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs.target')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs.target')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-import-scan')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-import-scan')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-import-cache')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-import-cache')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-mount')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-mount')),
                           CommandCaptureCommand(('rpm', '-qi', 'spl'), stdout=self.rpm_qi_spl_stdout),
                           CommandCaptureCommand(('dkms', 'install', 'spl/1.2.3.4'), rc=1, stderr='sample dkms error text'))
 
@@ -352,14 +328,6 @@ kernel modules are functioning properly.
 
     def test_initialise_driver_fail_dkms_zfs(self):
         self.add_commands(CommandCaptureCommand(('genhostid',)),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs.target')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs.target')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-import-scan')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-import-scan')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-import-cache')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-import-cache')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-mount')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-mount')),
                           CommandCaptureCommand(('rpm', '-qi', 'spl'), stdout=self.rpm_qi_spl_stdout),
                           CommandCaptureCommand(('dkms', 'install', 'spl/1.2.3.4')),
                           CommandCaptureCommand(('modprobe', 'spl')),
@@ -376,14 +344,6 @@ kernel modules are functioning properly.
 
     def test_initialise_driver_fail_modprobe_zfs(self):
         self.add_commands(CommandCaptureCommand(('genhostid',)),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs.target')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs.target')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-import-scan')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-import-scan')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-import-cache')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-import-cache')),
-                          CommandCaptureCommand(('systemctl', 'status', 'zfs-mount')),
-                          CommandCaptureCommand(('systemctl', 'disable', 'zfs-mount')),
                           CommandCaptureCommand(('rpm', '-qi', 'spl'), stdout=self.rpm_qi_spl_stdout),
                           CommandCaptureCommand(('dkms', 'install', 'spl/1.2.3.4')),
                           CommandCaptureCommand(('modprobe', 'spl')),


### PR DESCRIPTION
We are currently disabling a bunch of units in
`BlockDeviceZfs.initialise_driver`

One of them is `zfs.target`, which is the base initialization
unit in ZFS. Once this target is disabled, no other ZFS units
will start at boot.

This is an issue because, as a consequence of this, the
zfs-zed.service will not start, which we are heavily reliant
on in upcoming work.

Remove all disabling of units in this patch.

In managed mode, we will disable scan / cache at install
time in the lustre-ldiskfs-zfs spec.

In monitor mode, we will disable them in the installer script
that gets generated for installing ZFS, and we will
document that ZED *must*  be running at boot time.

Signed-off-by: Joe Grund <joe.grund@intel.com>