### PR TITLE
Fix detect file system with zfs target but zfs not installed on host

### DIFF
--- a/iml_common/blockdevices/blockdevice_linux.py
+++ b/iml_common/blockdevices/blockdevice_linux.py
@@ -224,7 +224,7 @@ class BlockDeviceLinux(BlockDevice):
         try:
             self._initialize_modules()
         except shell.Shell.CommandExecutionError:
-            log.info("ldiskfs is not installed, skipping device %s")
+            log.info("ldiskfs is not installed, skipping device %s" % device['path'])
             return self.TargetsInfo([], None)
 
         log.info("Searching device %s of type %s, uuid %s for a Lustre filesystem" % (device['path'], device['type'], device['uuid']))

--- a/iml_common/blockdevices/blockdevice_zfs.py
+++ b/iml_common/blockdevices/blockdevice_zfs.py
@@ -147,16 +147,16 @@ class BlockDeviceZfs(BlockDevice):
         if reread or not self._zfs_properties:
             self._zfs_properties = {}
 
-            ls = Shell.try_run(["zfs", "get", "-Hp", "-o", "property,value", "all", self._device_path])
+            result = Shell.run(["zfs", "get", "-Hp", "-o", "property,value", "all", self._device_path])
 
-            for line in ls.split("\n"):
-                try:
-                    key, value = line.split()
-                    self._zfs_properties[key] = value
-                except ValueError:                              # Be resilient to things we don't understand.
-                    if log:
-                        log.info("zfs get for %s returned %s which was not parsable." % (self._device_path, line))
-                    pass
+            if result.rc == 0:
+                for line in result.stdout.split("\n"):
+                    try:
+                        key, value = line.split()
+                        self._zfs_properties[key] = value
+                    except ValueError:                              # Be resilient to things we don't understand.
+                        if log:
+                            log.info("zfs get for %s returned %s which was not parsable." % (self._device_path, line))
 
         return self._zfs_properties
 

--- a/tests/blockdevices/test_blockdevice_zfs.py
+++ b/tests/blockdevices/test_blockdevice_zfs.py
@@ -83,8 +83,7 @@ kernel modules are functioning properly.
     def test_initialize_modules(self):
         self.patch_init_modules.stop()
 
-        self.add_commands(CommandCaptureCommand(('modprobe', 'osd_zfs')),
-                          CommandCaptureCommand(('modprobe', 'zfs')))
+        self.add_commands(CommandCaptureCommand(('/usr/sbin/udevadm', 'info', '--path=/module/zfs')))
 
         self.blockdevice._initialize_modules()
         self.assertTrue(self.blockdevice._modules_initialized)


### PR DESCRIPTION
EFS is failing on reactive-stack https://github.com/intel-hpdd/intel-manager-for-lustre/pull/467 http://jenkins.lotus.hpdd.lab.intel.com/job/integration-tests-existing-filesystem-configuration/arch=x86_64,distro=el7/4266//consoleFull

```
[01/May/2018:05:27:59] daemon INFO ActionRunner.run: f01ca27a-930f-49c1-b8eb-23f232d10250 detect_scan {u'target_devices': [{
u'path': u'/dev/disk/by-id/virtio-mds1-root', u'type': u'linux', u'uuid': None}, {u'path': u'zfs_pool_scsi0QEMU_QEMU_HARDDIS
K_disk1/mgt_index0', u'type': u'zfs', u'uuid': u'6125430025049729191'}, {u'path': u'zfs_pool_scsi0QEMU_QEMU_HARDDISK_disk2/o
st_index2', u'type': u'zfs', u'uuid': u'11902666986225848941'}, {u'path': u'zfs_pool_scsi0QEMU_QEMU_HARDDISK_disk3/ost_index
3', u'type': u'zfs', u'uuid': u'6351871981661674257'}, {u'path': u'zfs_pool_scsi0QEMU_QEMU_HARDDISK_disk4/ost_index0', u'typ
e': u'zfs', u'uuid': u'6728390406482401439'}, {u'path': u'zfs_pool_scsi0QEMU_QEMU_HARDDISK_disk5/ost_index1', u'type': u'zfs
', u'uuid': u'15033898493323192671'}]}
[01/May/2018:05:27:59] daemon INFO detect_scan called at 2018-05-01 05:27:59.866563 with target_devices saved on 2018-05-01
05:27:59.862758
[01/May/2018:05:27:59] daemon INFO Device /dev/disk/by-id/virtio-mds1-root had no UUID and so will not be examined for Lustr
e
[01/May/2018:05:27:59] daemon INFO ActionRunner.fail f01ca27a-930f-49c1-b8eb-23f232d10250: Traceback (most recent call last)
:

  File "/usr/lib/python2.7/site-packages/chroma_agent/device_plugins/action_runner.py", line 164, in run
    result = self.manager._session._client.action_plugins.run(self.action, agent_daemon_context, self.args)

  File "/usr/lib/python2.7/site-packages/chroma_agent/plugin_manager.py", line 303, in run
    return fn(**args)

  File "/usr/lib/python2.7/site-packages/chroma_agent/action_plugins/detect_scan.py", line 124, in detect_scan
    local_targets = LocalTargets(settings['target_devices'])

  File "/usr/lib/python2.7/site-packages/chroma_agent/action_plugins/detect_scan.py", line 48, in __init__
    targets = block_device.targets(uuid_name_to_target, device, daemon_log)

  File "/usr/lib/python2.7/site-packages/iml_common/blockdevices/blockdevice_zfs.py", line 196, in targets
    self._initialize_modules()

  File "/usr/lib/python2.7/site-packages/iml_common/blockdevices/blockdevice_zfs.py", line 49, in _initialize_modules
    Shell.try_run(['modprobe', 'osd_zfs'])

  File "/usr/lib/python2.7/site-packages/chroma_agent/lib/shell.py", line 106, in try_run
    raise AgentShell.CommandExecutionError(result, arg_list)

CommandExecutionError: Error (1) running 'modprobe osd_zfs': '' 'modprobe: FATAL: Module osd_zfs not found.
'
```

Reason being that during detection of lustre fs with zfs-backed targets, we generate knowledge of zpools that exist on shared block devices on the manager, this information results in target identities being recorded in the agent config store as targets of interest to be monitored.

When interrogating zfs targets identified in config store, an exception is raised if the given agent host does not have zfs installed as the agent attempts to load the modules.

What should happen is that in monitored mode the modules are detected using an idempotent technique such as `/usr/sbin/udevadm info --path=/module/zfs`, rather than attempting to load the modules using `modprobe`. 

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>