### PR TITLE
Remove zfs dkms hack from initialise routine

### DIFF
--- a/tests/blockdevices/test_blockdevice_zfs.py
+++ b/tests/blockdevices/test_blockdevice_zfs.py
@@ -257,29 +257,9 @@ kernel modules are functioning properly.
         self.assertRanAllCommandsInOrder()
 
     def test_initialise_driver(self):
-        self.add_commands(CommandCaptureCommand(('genhostid',)),
-                          CommandCaptureCommand(('rpm', '-qi', 'spl'), stdout=self.rpm_qi_spl_stdout),
-                          CommandCaptureCommand(('dkms', 'install', 'spl/1.2.3.4')),
-                          CommandCaptureCommand(('modprobe', 'spl')),
-                          CommandCaptureCommand(('rpm', '-qi', 'zfs'), stdout=self.rpm_qi_zfs_stdout),
-                          CommandCaptureCommand(('dkms', 'install', 'zfs/0.6.5.7')),
-                          CommandCaptureCommand(('modprobe', 'zfs')))
+        self.add_commands(CommandCaptureCommand(('genhostid',)))
 
         with mock.patch.object(path, 'isfile', return_value=False):
-            result = BlockDeviceZfs.initialise_driver(True)
-
-        self.assertEqual(result, None)
-        self.assertRanAllCommandsInOrder()
-
-    def test_initialise_driver_file_exists(self):
-        self.add_commands(CommandCaptureCommand(('rpm', '-qi', 'spl'), stdout=self.rpm_qi_spl_stdout),
-                          CommandCaptureCommand(('dkms', 'install', 'spl/1.2.3.4')),
-                          CommandCaptureCommand(('modprobe', 'spl')),
-                          CommandCaptureCommand(('rpm', '-qi', 'zfs'), stdout=self.rpm_qi_zfs_stdout),
-                          CommandCaptureCommand(('dkms', 'install', 'zfs/0.6.5.7')),
-                          CommandCaptureCommand(('modprobe', 'zfs')))
-
-        with mock.patch.object(path, 'isfile', return_value=True):
             result = BlockDeviceZfs.initialise_driver(True)
 
         self.assertEqual(result, None)
@@ -292,46 +272,6 @@ kernel modules are functioning properly.
             result = BlockDeviceZfs.initialise_driver(True)
 
         self.assertIn('sample genhostid error text', result)
-        self.assertRanAllCommandsInOrder()
-
-    def test_initialise_driver_fail_dkms_spl(self):
-        self.add_commands(CommandCaptureCommand(('genhostid',)),
-                          CommandCaptureCommand(('rpm', '-qi', 'spl'), stdout=self.rpm_qi_spl_stdout),
-                          CommandCaptureCommand(('dkms', 'install', 'spl/1.2.3.4'), rc=1, stderr='sample dkms error text'))
-
-        with mock.patch.object(path, 'isfile', return_value=False):
-            result = BlockDeviceZfs.initialise_driver(True)
-
-        self.assertIn('sample dkms error text', result)
-        self.assertRanAllCommandsInOrder()
-
-    def test_initialise_driver_fail_dkms_zfs(self):
-        self.add_commands(CommandCaptureCommand(('genhostid',)),
-                          CommandCaptureCommand(('rpm', '-qi', 'spl'), stdout=self.rpm_qi_spl_stdout),
-                          CommandCaptureCommand(('dkms', 'install', 'spl/1.2.3.4')),
-                          CommandCaptureCommand(('modprobe', 'spl')),
-                          CommandCaptureCommand(('rpm', '-qi', 'zfs'), stdout=self.rpm_qi_zfs_stdout),
-                          CommandCaptureCommand(('dkms', 'install', 'zfs/0.6.5.7'), rc=1, stderr='sample dkms error text'))
-
-        with mock.patch.object(path, 'isfile', return_value=False):
-            result = BlockDeviceZfs.initialise_driver(True)
-
-        self.assertIn('sample dkms error text', result)
-        self.assertRanAllCommandsInOrder()
-
-    def test_initialise_driver_fail_modprobe_zfs(self):
-        self.add_commands(CommandCaptureCommand(('genhostid',)),
-                          CommandCaptureCommand(('rpm', '-qi', 'spl'), stdout=self.rpm_qi_spl_stdout),
-                          CommandCaptureCommand(('dkms', 'install', 'spl/1.2.3.4')),
-                          CommandCaptureCommand(('modprobe', 'spl')),
-                          CommandCaptureCommand(('rpm', '-qi', 'zfs'), stdout=self.rpm_qi_zfs_stdout),
-                          CommandCaptureCommand(('dkms', 'install', 'zfs/0.6.5.7')),
-                          CommandCaptureCommand(('modprobe', 'zfs'), rc=1, stderr='sample modprobe error text'))
-
-        with mock.patch.object(path, 'isfile', return_value=False):
-            result = BlockDeviceZfs.initialise_driver(True)
-
-        self.assertIn('sample modprobe error text', result)
         self.assertRanAllCommandsInOrder()
 
     def test_initialise_driver_monitor_mode(self):


### PR DESCRIPTION
There is a workaround for https://github.com/zfsonlinux/zfs/issues/3801 at https://github.com/intel-hpdd/iml-common/blob/72f737d67d0942a687d2d9b5cefb13574199bcb5/iml_common/blockdevices/blockdevice_zfs.py#L327

that can probably be removed because it should have been fixed in dkms

Signed-off-by: Tom Nabarro <tom.nabarro@intel.com>