### PR TITLE
Re-home to the manager-for-lustre-devel repo

### DIFF
--- a/iml_common/scm_version.py
+++ b/iml_common/scm_version.py
@@ -1,4 +1,4 @@
-VERSION = "1.3.3-6-g4ac5707"
+VERSION = "1.3.3-5-gaacc585"
 PACKAGE_VERSION = "1.3.3"
 BUILD = ""
 IS_RELEASE = False

--- a/include/copr.mk
+++ b/include/copr.mk
@@ -12,7 +12,7 @@ endif
 
 ifneq ($(filter iml_%,$(MAKECMDGOALS)),)
   COPR_CONFIG := --config include/copr-mfl
-  OWNER_PROJECT = managerforlustre/manager-for-lustre
+  OWNER_PROJECT = managerforlustre/manager-for-lustre-devel
 else
   # local settings
   -include copr-local.mk

--- a/include/travis/mock_build_test.sh
+++ b/include/travis/mock_build_test.sh
@@ -18,9 +18,9 @@ fi
 ed <<"EOF" /etc/mock/default.cfg
 $i
 
-[copr-be.cloud.fedoraproject.org_results_managerforlustre_manager-for-lustre_epel-7-x86_64_]
-name=added from: https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/epel-7-x86_64/
-baseurl=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre/epel-7-x86_64/
+[copr-be.cloud.fedoraproject.org_results_managerforlustre_manager-for-lustre-devel_epel-7-x86_64_]
+name=added from: https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre-devel/epel-7-x86_64/
+baseurl=https://copr-be.cloud.fedoraproject.org/results/managerforlustre/manager-for-lustre-devel/epel-7-x86_64/
 enabled=1
 .
 wq


### PR DESCRIPTION
While we develop the next version, make sure builds happen
in the development repo.

Create-Tag: 1.4.0
Signed-off-by: Brian J. Murrell <brian.murrell@intel.com>