### PR TITLE
Remove lockfile dep

### DIFF
--- a/python-iml-common.spec.in
+++ b/python-iml-common.spec.in
@@ -24,8 +24,6 @@ BuildArch:      noarch
 BuildRequires:  python2-devel
 BuildRequires:  python-setuptools
 
-Requires:       python-lockfile==0.9.1
-
 %description
 A Python package that contains common components for the IML project Different
 areas of the IML project utilise common code that is shared distributed through

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 pytest
 Django==1.4.5
 twine
-lockfile==0.9.1


### PR DESCRIPTION
Lockfile has been removed from code for the 4.1 release.

Remove it's inclusion as a dep.

Signed-off-by: Joe Grund <joe.grund@intel.com>