### PR TITLE
Remove modprobe as a method of verifying modules are running

### DIFF
--- a/iml_common/blockdevices/blockdevice.py
+++ b/iml_common/blockdevices/blockdevice.py
@@ -57,26 +57,18 @@ class BlockDevice(object):
         self._device_type = device_type
         self._device_path = device_path
 
-    def _initialize_modules(self):
-        """
-        Called before operations that might result the filesystem specific modules to be loaded.
-
-        :return: None
-        """
-        return None
+    def _check_module(self):
+        """ Verify relevant kernel module is loaded """
+        pass
 
     @abc.abstractproperty
     def filesystem_type(self):
-        """
-        Return type of occupying filesystem(s)
-        """
+        """ Return type of occupying filesystem(s) """
         pass
 
     @abc.abstractproperty
     def filesystem_info(self):
-        """
-        Return message regarding occupying filesystem(s) that reside on this block device
-        """
+        """ Occupying filesystem(s) that reside on this block device """
         pass
 
     @abc.abstractproperty

--- a/iml_common/filesystems/filesystem.py
+++ b/iml_common/filesystems/filesystem.py
@@ -3,7 +3,7 @@
 # license that can be found in the LICENSE file.
 
 
-from ..lib import shell
+from ..lib.shell import Shell
 from ..lib import util
 import abc
 
@@ -58,44 +58,39 @@ class FileSystem(object):
 
     @abc.abstractmethod
     def label(self):
-        """ :return: Returns the label of the filesystem """
+        """ Returns the label of the filesystem """
         pass
 
     def device_path(self):
-        """ :return: The path to the device the contains/will contain the filesystem """
+        """ The path to the device the contains/will contain the filesystem """
         return self._device_path
 
     @property
     def inode_size(self):
-        """ :return: The inode size of the filesystem, returns 0 if inode size not supported """
+        """ The inode size of the filesystem, returns 0 if inode size not supported """
         return 0
 
     @property
     def inode_count(self):
-        """ :return: The inode count of the filesystem, returns 0 if inode count not supported """
+        """ The inode count of the filesystem, returns 0 if inode count not supported """
         return 0
 
     def mount(self, mount_point):
-        """ :return: Mount the file system, raise an exception on error. """
-        self._initialize_modules()
-
-        result = shell.Shell.run(['mount', '-t', 'lustre', self._device_path, mount_point])
+        """ Mount the file system, raise an exception on error. """
+        result = Shell.run(['mount', '-t', 'lustre', self._device_path, mount_point])
 
         if result.rc in [self.RC_MOUNT_INPUT_OUTPUT_ERROR,
                          self.RC_MOUNT_ENOENT_ERROR,
                          self.RC_MOUNT_ESHUTDOWN_ERROR]:
             # HYD-1040, LU-9838, LU-9976: Sometimes we should retry on a failed registration
-            result = shell.Shell.run(['mount', '-t', 'lustre', self._device_path, mount_point])
+            result = Shell.run(['mount', '-t', 'lustre', self._device_path, mount_point])
 
         if result.rc != self.RC_MOUNT_SUCCESS:
             raise RuntimeError("Error (%s) mounting '%s': '%s' '%s'" % (result.rc, mount_point, result.stdout, result.stderr))
 
-
     def umount(self):
         """ :return: Umount the file system, raise an exception on error. """
-        self._initialize_modules()
-
-        return shell.Shell.try_run(["umount", self._device_path])
+        return Shell.try_run(["umount", self._device_path])
 
     def mount_path(self, target_name):
         """

--- a/iml_common/filesystems/filesystem_ldiskfs.py
+++ b/iml_common/filesystems/filesystem_ldiskfs.py
@@ -16,14 +16,9 @@ class FileSystemLdiskfs(FileSystem, BlockDeviceLinux):
     # in the read from blkid. But listing both is safe.
     _supported_filesystems = ['ldiskfs', 'ext4']
 
-    def __init__(self, fstype, device_path):
-        super(FileSystemLdiskfs, self).__init__(fstype, device_path)
-
-        self._modules_initialized = False
-
     @property
     def label(self):
-        self._initialize_modules()
+        self._check_module()
 
         blkid_output = shell.Shell.try_run(['blkid', '-c/dev/null', '-o', 'value', '-s', 'LABEL', self._device_path])
 
@@ -31,7 +26,7 @@ class FileSystemLdiskfs(FileSystem, BlockDeviceLinux):
 
     @property
     def inode_size(self):
-        self._initialize_modules()
+        self._check_module()
 
         dumpe2fs_output = shell.Shell.try_run(['dumpe2fs', '-h', self._device_path])
 
@@ -39,7 +34,7 @@ class FileSystemLdiskfs(FileSystem, BlockDeviceLinux):
 
     @property
     def inode_count(self):
-        self._initialize_modules()
+        self._check_module()
 
         dumpe2fs_output = shell.Shell.try_run(["dumpe2fs", "-h", self._device_path])
 
@@ -50,7 +45,7 @@ class FileSystemLdiskfs(FileSystem, BlockDeviceLinux):
         return shell.Shell.try_run(["umount", os.path.realpath(self._device_path)])
 
     def mkfs(self, target_name, options):
-        self._initialize_modules()
+        self._check_module()
 
         shell.Shell.try_run(['mkfs.lustre'] + options + [self._device_path])
 

--- a/iml_common/filesystems/filesystem_zfs.py
+++ b/iml_common/filesystems/filesystem_zfs.py
@@ -14,7 +14,6 @@ class FileSystemZfs(FileSystem, BlockDeviceZfs):
     def __init__(self, fstype, device_path):
         super(FileSystemZfs, self).__init__(fstype, device_path)
 
-        self._modules_initialized = False
         self._zfs_properties = None
 
     @property
@@ -52,7 +51,7 @@ class FileSystemZfs(FileSystem, BlockDeviceZfs):
         :param options: list of options to supply to mkfs command
         :return: dict of new target info
         """
-        self._initialize_modules()
+        self._check_module()
 
         # set 'failmode=panic' property on underlying device (zpool)
         BlockDeviceZfs('zfs', self._device_path).failmode = 'panic'

--- a/tests/blockdevices/blockdevice_base_tests.py
+++ b/tests/blockdevices/blockdevice_base_tests.py
@@ -26,7 +26,7 @@ class BaseTestBD(object):
             self.blockdevice = None
 
         @abc.abstractmethod
-        def test_initialize_modules(self):
+        def test_check_module(self):
             pass
 
         @abc.abstractmethod

--- a/tests/blockdevices/test_blockdevice_linux.py
+++ b/tests/blockdevices/test_blockdevice_linux.py
@@ -9,21 +9,19 @@ class TestBlockDeviceLinux(BaseTestBD.BaseTestBlockDevice):
     def setUp(self):
         super(TestBlockDeviceLinux, self).setUp()
 
-        self.patch_init_modules = mock.patch.object(BlockDeviceLinux, '_initialize_modules')
+        self.patch_init_modules = mock.patch.object(BlockDeviceLinux, '_check_module')
         self.patch_init_modules.start()
 
         self.blockdevice = BlockDeviceLinux('linux', '/dev/sda1')
 
         self.addCleanup(mock.patch.stopall)
 
-    def test_initialize_modules(self):
+    def test_check_module(self):
         self.patch_init_modules.stop()
 
-        self.add_commands(CommandCaptureCommand(('modprobe', 'osd_ldiskfs'), rc=1),
-                          CommandCaptureCommand(('modprobe', 'ldiskfs')))
+        self.add_commands(CommandCaptureCommand(('/usr/sbin/udevadm', 'info', '--path=/module/ldiskfs')))
 
-        self.blockdevice._initialize_modules()
-        self.assertTrue(self.blockdevice._modules_initialized)
+        self.blockdevice._check_module()
 
         self.assertRanAllCommandsInOrder()
 

--- a/tests/blockdevices/test_blockdevice_zfs.py
+++ b/tests/blockdevices/test_blockdevice_zfs.py
@@ -69,7 +69,7 @@ kernel modules are functioning properly.
         self.mock_remove = mock.Mock()
         mock.patch('os.makedirs', self.mock_makedirs).start()
         mock.patch('os.remove', self.mock_remove).start()
-        self.patch_init_modules = mock.patch.object(BlockDeviceZfs, '_initialize_modules')
+        self.patch_init_modules = mock.patch.object(BlockDeviceZfs, '_check_module')
         self.patch_init_modules.start()
         self.mock_open = mock.mock_open()
         mock.patch('__builtin__.open', self.mock_open, create=True).start()
@@ -80,13 +80,12 @@ kernel modules are functioning properly.
         self.reset_command_capture_logs()
         self.addCleanup(mock.patch.stopall)
 
-    def test_initialize_modules(self):
+    def test_check_module(self):
         self.patch_init_modules.stop()
 
         self.add_commands(CommandCaptureCommand(('/usr/sbin/udevadm', 'info', '--path=/module/zfs')))
 
-        self.blockdevice._initialize_modules()
-        self.assertTrue(self.blockdevice._modules_initialized)
+        self.blockdevice._check_module()
 
         self.assertRanAllCommandsInOrder()
 

--- a/tests/filesystems/test_filesystem_ldiskfs.py
+++ b/tests/filesystems/test_filesystem_ldiskfs.py
@@ -16,21 +16,19 @@ class TestFileSystemLdiskfs(CommandCaptureTestCase):
         self.type_prop_mock = mock.PropertyMock(return_value='ldiskfs')
         mock.patch.object(BlockDeviceLinux, 'filesystem_type', self.type_prop_mock).start()
 
-        self.patch_init_modules = mock.patch.object(FileSystemLdiskfs, '_initialize_modules')
+        self.patch_init_modules = mock.patch.object(FileSystemLdiskfs, '_check_module')
         self.patch_init_modules.start()
 
         self.filesystem = FileSystemLdiskfs('ldiskfs', '/dev/sda1')
 
         self.addCleanup(mock.patch.stopall)
 
-    def test_initialize_modules(self):
+    def test_check_module(self):
         self.patch_init_modules.stop()
 
-        self.add_commands(CommandCaptureCommand(('modprobe', 'osd_ldiskfs'), rc=1),
-                          CommandCaptureCommand(('modprobe', 'ldiskfs')))
+        self.add_commands(CommandCaptureCommand(('/usr/sbin/udevadm', 'info', '--path=/module/ldiskfs')))
 
-        self.filesystem._initialize_modules()
-        self.assertTrue(self.filesystem._modules_initialized)
+        self.filesystem._check_module()
 
         self.assertRanAllCommandsInOrder()
 

--- a/tests/filesystems/test_filesystem_zfs.py
+++ b/tests/filesystems/test_filesystem_zfs.py
@@ -17,7 +17,7 @@ class TestFileSystemZFS(CommandCaptureTestCase):
         self.type_patcher = mock.patch.object(BlockDeviceZfs, 'filesystem_type', self.type_prop_mock)
         self.type_patcher.start()
 
-        self.patch_init_modules = mock.patch.object(FileSystemZfs, '_initialize_modules')
+        self.patch_init_modules = mock.patch.object(FileSystemZfs, '_check_module')
         self.patch_init_modules.start()
 
         self.filesystem = FileSystemZfs('zfs', 'zpool1')


### PR DESCRIPTION
There are numerous occurrences of `modprobe` which are used to verify that the relevant modules are initialised before operations are performed on `zfs` and `ldiskfs` backed devices. As part of #36 this should be replaced with idempotent mechanisms of verifying loaded modules where necessary, leaving initialisation of modules to systemd units activated on start-up of IML services.